### PR TITLE
Restore Lagomorph damage modifier

### DIFF
--- a/Resources/Prototypes/_Starlight/Entities/Mobs/Species/lagomorph.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/Species/lagomorph.yml
@@ -127,4 +127,9 @@
       state: "creampie_human"
       visible: false
 # for fragile electronics like consoles or shuttle engines.
-
+- type: damageModifierSet
+  id: Lagomorph
+  coefficients:
+    Blunt: 0.9
+    Cold: 0.75
+    Heat: 1.25


### PR DESCRIPTION
## What changed

- Restored the Starlight `Lagomorph` damage modifier set.
- Kept the existing Project Verdant Lagomorph entity changes untouched.

## Why

The Lagomorph entity still referenced `damageModifierSet: Lagomorph`, but the matching prototype definition was lost during the Starlight merge. This caused repeated `invalid ProtoId<DamageModifierSetPrototype>: Lagomorph` errors whenever Lagomorph suffocation recovery applied damage recovery.

## Validation

- Compared the definition against the Starlight source.
- Confirmed the branch changes only `Resources/Prototypes/_Starlight/Entities/Mobs/Species/lagomorph.yml`.
- Confirmed the restored coefficients are `Blunt: 0.9`, `Cold: 0.75`, and `Heat: 1.25`.